### PR TITLE
Added a variable to set timezone for scheduler.

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -27,6 +27,7 @@ devture_postgres_backup_keep_days: 7
 devture_postgres_backup_keep_weeks: 4
 devture_postgres_backup_keep_months: 12
 devture_postgres_backup_healthcheck_port: "8080"
+devture_postgres_backup_timezone: 'UTC'
 
 # devture_postgres_backup_databases contains a list of database names to back up
 devture_postgres_backup_databases: []

--- a/templates/env.j2
+++ b/templates/env.j2
@@ -10,3 +10,4 @@ BACKUP_KEEP_WEEKS={{ devture_postgres_backup_keep_weeks }}
 BACKUP_KEEP_MONTHS={{ devture_postgres_backup_keep_months }}
 HEALTHCHECK_PORT={{ devture_postgres_backup_healthcheck_port }}
 POSTGRES_PORT={{ devture_postgres_backup_connection_port }}
+TZ={{ devture_postgres_backup_timezone }}


### PR DESCRIPTION
As backup can be scheduled at some time defined via cron-like format string it's need to have correct timezone set for postgres-backup container. "TZ" environment variable is the recommended way for it (see [README](https://github.com/prodrigestivill/docker-postgres-backup-local/blob/main/README.md#environment-variables) of docker-postgres-backup-local).