### PR TITLE
Make 'keep_mins' configurable

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -25,6 +25,7 @@ devture_postgres_backup_extra_opts: "-Z9 --schema=public --blobs"
 devture_postgres_backup_schedule: "@daily"
 devture_postgres_backup_keep_days: 7
 devture_postgres_backup_keep_weeks: 4
+devture_postgres_backup_keep_mins: 1440
 devture_postgres_backup_keep_months: 12
 devture_postgres_backup_healthcheck_port: "8080"
 devture_postgres_backup_timezone: 'UTC'

--- a/templates/env.j2
+++ b/templates/env.j2
@@ -7,6 +7,7 @@ POSTGRES_EXTRA_OPTS={{ devture_postgres_backup_extra_opts }}
 SCHEDULE={{ devture_postgres_backup_schedule }}
 BACKUP_KEEP_DAYS={{ devture_postgres_backup_keep_days }}
 BACKUP_KEEP_WEEKS={{ devture_postgres_backup_keep_weeks }}
+BACKUP_KEEP_MINS={{ devture_postgres_backup_keep_mins }}
 BACKUP_KEEP_MONTHS={{ devture_postgres_backup_keep_months }}
 HEALTHCHECK_PORT={{ devture_postgres_backup_healthcheck_port }}
 POSTGRES_PORT={{ devture_postgres_backup_connection_port }}


### PR DESCRIPTION
The value is passed to the 'find' command, which cleans up data stored within the 'last' folder. Upstream defaults to '1440', which is one day in minutes.